### PR TITLE
Remove go.work* from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+go.work*
 dist/

--- a/go.work
+++ b/go.work
@@ -1,6 +1,0 @@
-go 1.24.0
-
-use (
-	.
-	./testdata/src/a
-)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,0 @@
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=


### PR DESCRIPTION
Delete go.work because committing is discouraged.

> It is generally inadvisable to commit go.work files into version control systems
> https://go.dev/ref/mod#go-work-file

@sho-hata Could you please review it?