### PR TITLE
Update .goreleaser.yaml: Remove archives.replacements

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -10,19 +11,12 @@ builds:
       - linux
       - windows
       - darwin
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^test:'
+      - "^test:"


### PR DESCRIPTION
Remove `archives.replacements` from `.goreleaser.yaml`.
`archives.replacements` has been deprecated.
see https://goreleaser.com/deprecations/#archivesreplacements

@sho-hata Could you please review it?

